### PR TITLE
v0.2.0 ImagePuller as aceptadora.New() param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2020-11-18
+### Changed
+- BREAKING: `aceptadora.New()` now accepts an `ImagePuller` instead of creating it, and `aceptadora.Config` no longer contains the `aceptadora.ImagePullerConfig`.
+  This allows reusing same ImagePuller for multiple aceptadora instances (one per test probably) and taking advantage of the image cache that `ImagePuller` has to avoid pulling same image multiple times.
+
 ## [0.1.0] - 2020-10-14
 ### Added
 - Initial public version

--- a/acceptance/config/default.env
+++ b/acceptance/config/default.env
@@ -1,12 +1,12 @@
 # Specific config for acceptance tester
 # This domain is skipped as it's used for images built locally
-ACCEPTANCE_ACEPTADORA_IMAGEPULLER_REPO_0_DOMAIN=cabify.local
-ACCEPTANCE_ACEPTADORA_IMAGEPULLER_REPO_0_SKIPPULLING=true
+ACCEPTANCE_IMAGEPULLER_REPO_0_DOMAIN=company.local
+ACCEPTANCE_IMAGEPULLER_REPO_0_SKIPPULLING=true
 
 # Don't pull gitlab otherwise we need credentials
 # Pull the images manually for the test please
-ACCEPTANCE_ACEPTADORA_IMAGEPULLER_REPO_1_DOMAIN=gitlab.com
-ACCEPTANCE_ACEPTADORA_IMAGEPULLER_REPO_1_SKIPPULLING=true
+ACCEPTANCE_IMAGEPULLER_REPO_1_DOMAIN=gitlab.com
+ACCEPTANCE_IMAGEPULLER_REPO_1_SKIPPULLING=true
 
 # ACCEPTANCE_SERVICESADDRESS tells our acceptance suite where the running services are binding their ports
 ACCEPTANCE_SERVICESADDRESS=127.0.0.1

--- a/acceptance/config/gitlab.env
+++ b/acceptance/config/gitlab.env
@@ -1,7 +1,7 @@
 # Specific config for acceptance tester
-ACCEPTANCE_ACEPTADORA_IMAGEPULLER_REPO_0_DOMAIN=${CI_REGISTRY}
-ACCEPTANCE_ACEPTADORA_IMAGEPULLER_REPO_0_USERNAME=gitlab-ci-token
-ACCEPTANCE_ACEPTADORA_IMAGEPULLER_REPO_0_PASSWORD=${CI_JOB_TOKEN}
+ACCEPTANCE_IMAGEPULLER_REPO_0_DOMAIN=${CI_REGISTRY}
+ACCEPTANCE_IMAGEPULLER_REPO_0_USERNAME=gitlab-ci-token
+ACCEPTANCE_IMAGEPULLER_REPO_0_PASSWORD=${CI_JOB_TOKEN}
 
 # ACCEPTANCE_SERVICESADDRESS tells our acceptance suite where the running services are binding their ports
 # In case of gitlab, this is the docker-in-docker host, which is `docker`

--- a/acceptance/suite/acceptance_suite_test.go
+++ b/acceptance/suite/acceptance_suite_test.go
@@ -16,7 +16,8 @@ import (
 const expectedMockedDependencyInventedHTTPStatusCode = 288
 
 type Config struct {
-	Aceptadora aceptadora.Config
+	Aceptadora  aceptadora.Config
+	ImagePuller aceptadora.ImagePullerConfig
 
 	// ServicesAddress is the address where services started by aceptadora can be found
 	// It differs from env to env, and it's set up in env-specific configs
@@ -46,7 +47,8 @@ func (s *acceptanceSuite) SetupSuite() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	s.aceptadora = aceptadora.New(s.T(), s.cfg.Aceptadora)
+	imagePuller := aceptadora.NewImagePuller(s.T(), s.cfg.ImagePuller)
+	s.aceptadora = aceptadora.New(s.T(), imagePuller, s.cfg.Aceptadora)
 	s.aceptadora.PullImages(ctx)
 
 	s.startMockedProxyDependency()

--- a/aceptadora.go
+++ b/aceptadora.go
@@ -15,8 +15,6 @@ import (
 type Config struct {
 	YAMLDir  string `default:"./"`
 	YAMLName string `default:"aceptadora.yml"`
-
-	ImagePuller ImagePullerConfig
 }
 
 type Aceptadora struct {
@@ -34,7 +32,7 @@ type Aceptadora struct {
 
 // New creates a new Aceptadora. It will try to load the YAML config from the path provided by Config
 // If something goes wrong, it will use testing.T to fail.
-func New(t *testing.T, cfg Config) *Aceptadora {
+func New(t *testing.T, imagePuller ImagePuller, cfg Config) *Aceptadora {
 	if _, ok := os.LookupEnv("TESTER_ADDRESS"); !ok {
 		os.Setenv("TESTER_ADDRESS", getLocalIP())
 	}
@@ -49,7 +47,7 @@ func New(t *testing.T, cfg Config) *Aceptadora {
 		require:     require.New(t),
 		cfg:         cfg,
 		yaml:        yaml,
-		imagePuller: NewImagePuller(t, cfg.ImagePuller),
+		imagePuller: imagePuller,
 		services:    map[string]*Runner{},
 	}
 }


### PR DESCRIPTION
Instead of instantiating ImagePuller for each aceptadora, we now can
reuse a global one (for the test suite). This will avoid pulling same
image for each test where a new aceptadora is created every time.

We need this as docker repository is now imposing rate limit and
introducing latency on docker pulls, and we're seeing times of up to
2.5s to just check that we have the latest image.

This is a breaking change.