### PR TITLE
v0.2.1 Fix ImagePuller authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2020-11-18
+### Fixed
+- `ImagePuller` authentication.
+
 ## [0.2.0] - 2020-11-18
 ### Changed
 - BREAKING: `aceptadora.New()` now accepts an `ImagePuller` instead of creating it, and `aceptadora.Config` no longer contains the `aceptadora.ImagePullerConfig`.

--- a/puller.go
+++ b/puller.go
@@ -89,7 +89,7 @@ func (i *ImagePullerImpl) tryPullImage(ctx context.Context, imageName string) er
 
 	var authStr string
 	if ok {
-		encodedJSON, err := json.Marshal(repoCfg)
+		encodedJSON, err := json.Marshal(repoCfg.Auth)
 		if err != nil {
 			return fmt.Errorf("encoding JSON auth: %v", err)
 		}


### PR DESCRIPTION
We were serializing the wrong struct, and since we're not testing the
auth in the open source version, that went unnoticed.

We really need an authenticated build / gitlab CI job for this one.