### PR TITLE
Refactored image pulling logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Refactored image pulling logging.
 
 ## [0.2.1] - 2020-11-18
 ### Fixed

--- a/aceptadora.go
+++ b/aceptadora.go
@@ -55,8 +55,7 @@ func New(t *testing.T, imagePuller ImagePuller, cfg Config) *Aceptadora {
 // This allows doing this outside of the context of the test, and avoid unrelated flaky timeouts in the tests
 // happening when most of the context has been consumed by pulling the image
 func (a *Aceptadora) PullImages(ctx context.Context) {
-	for svcName, svc := range a.yaml.Services {
-		a.t.Logf("Pulling image %q for %q", svc.Image, svcName)
+	for _, svc := range a.yaml.Services {
 		a.imagePuller.Pull(ctx, svc.Image)
 	}
 }

--- a/aceptadora.go
+++ b/aceptadora.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -57,9 +56,8 @@ func New(t *testing.T, imagePuller ImagePuller, cfg Config) *Aceptadora {
 // happening when most of the context has been consumed by pulling the image
 func (a *Aceptadora) PullImages(ctx context.Context) {
 	for svcName, svc := range a.yaml.Services {
-		t0 := time.Now()
+		a.t.Logf("Pulling image %q for %q", svc.Image, svcName)
 		a.imagePuller.Pull(ctx, svc.Image)
-		a.t.Logf("Pulled image %q for %q in %s", svc.Image, svcName, time.Since(t0))
 	}
 }
 

--- a/puller.go
+++ b/puller.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
@@ -75,6 +76,7 @@ type image struct {
 }
 
 func (i *ImagePullerImpl) tryPullImage(ctx context.Context, imageName string) error {
+	t0 := time.Now()
 	ref, err := reference.ParseNamed(imageName)
 	if err != nil {
 		return fmt.Errorf("can't parse image name %q: %w", imageName, err)
@@ -106,6 +108,8 @@ func (i *ImagePullerImpl) tryPullImage(ctx context.Context, imageName string) er
 		return fmt.Errorf("can't pull image %s: %v", imageName, err)
 	}
 	defer out.Close()
+
+	i.t.Logf("Pulled image %q in %s", imageName, time.Since(t0))
 
 	_, _ = io.Copy(
 		testLogsWriter{i.t, fmt.Sprintf("Image %q puller", imageName)},


### PR DESCRIPTION
This change aims to fix the following contradictory logs:

```
puller.go:86: Not pulling <image name>: disabled by config for domain <domain>
aceptadora.go:86: Pulled image <image name> for <service name> in <time>
```
