### PR TITLE
Add StopTimeout default to 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `Runner.StopWithTimeout` and `Config.StopTimeout` to stop containers within the provided time, 0 by default to reduce the tear down time.
+
 ### Changed
 - Refactored image pulling logging.
 

--- a/aceptadora.go
+++ b/aceptadora.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,6 +15,10 @@ import (
 type Config struct {
 	YAMLDir  string `default:"./"`
 	YAMLName string `default:"aceptadora.yml"`
+
+	// StopTimeout will be used to stop containers gracefully.
+	// If zero (default), then containers will be forced to stop immediately saving some tear down time.
+	StopTimeout time.Duration `default:"0s"`
 }
 
 type Aceptadora struct {
@@ -96,7 +101,7 @@ func (a *Aceptadora) Stop(ctx context.Context, name string) {
 		return
 	}
 
-	err := svc.Stop(ctx)
+	err := svc.StopWithTimeout(ctx, a.cfg.StopTimeout)
 	assert.NoError(a.t, err, "Can't stop service %q in time: %s", err)
 	a.services[name] = nil
 }

--- a/runner.go
+++ b/runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -144,12 +145,22 @@ func (r *Runner) attachAndStreamLogs(ctx context.Context) {
 	r.logsStreamDoneCh = r.streamLogs(r.response)
 }
 
+// Stop will try to stop the container within the context provided.
 func (r *Runner) Stop(ctx context.Context) error {
+	return r.stop(ctx, nil)
+}
+
+// StopWithTimeout will stop the containers within the given timeout, if 0 it's just a force stop.
+func (r *Runner) StopWithTimeout(ctx context.Context, timeout time.Duration) error {
+	return r.stop(ctx, &timeout)
+}
+
+func (r *Runner) stop(ctx context.Context, timeout *time.Duration) error {
 	if r == nil || r.client == nil {
 		// nothing to stop
 		return nil
 	}
-	if err := r.client.ContainerStop(ctx, r.container.ID, nil); err != nil {
+	if err := r.client.ContainerStop(ctx, r.container.ID, timeout); err != nil {
 		r.t.Errorf("Error stopping container %s: %v", r.container.ID, err)
 	}
 


### PR DESCRIPTION
If we provide timeout=0 to docker stop operation, it will happen
earlier, and since we don't care about graceful shutdowns in tests, it
should be okay.

Configurable by `Config.StopTimeout`.