### PR TITLE
Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The [acceptance tests](./acceptance/suite/acceptance_suite_test.go) of this pack
 
 Long story short:
  - Define your service in a YAML file inspired by docker-compose format, with an idiomatic name of [`aceptadora.yml`](./acceptance/aceptadora.yml)
- - Define your environment variables in [some `config.env` files](./acceptance/config.env)
+ - Define your environment variables in [some `config.env` files](./acceptance/config/)
  - Load them in your test:
  ```go
 	aceptadora.SetEnv(


### PR DESCRIPTION
It just fix a broken link to the env files I've detected while reading the documentation. I hope I've pointed it to the right place 🤞 😅 