### PR TITLE
Use client.FromEnv when creating the docker client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2] - 2024-07-31
+### Fixed
+- Use `client.FromEnv` when creating docker client
+
 ## [0.5.1] - 2024-07-31
 ### Update
 - Bump `docker/docker` to `v26.1.4`

--- a/puller.go
+++ b/puller.go
@@ -99,7 +99,7 @@ func (i *ImagePullerImpl) tryPullImage(ctx context.Context, imageName string) er
 		authStr = base64.URLEncoding.EncodeToString(encodedJSON)
 	}
 
-	cli, err := client.NewClientWithOpts()
+	cli, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
 		return fmt.Errorf("creating docker client: %v", err)
 	}

--- a/runner.go
+++ b/runner.go
@@ -63,7 +63,7 @@ func (r *Runner) startContainer(ctx context.Context) {
 
 func (r *Runner) createDockerClient() {
 	var err error
-	r.client, err = client.NewClientWithOpts()
+	r.client, err = client.NewClientWithOpts(client.FromEnv)
 	r.require.NoError(err, "Unable to create a docker client: %v", err)
 }
 


### PR DESCRIPTION
During the bump, I replaced the deprecated `client.NewEnvClient()` by `client.NewClientWithOpts()` but I missed the `client.FromEnv` opt. ([#1](https://github.com/cabify/aceptadora/pull/14/files#diff-6a0e5654f4d38bb727e30127be563558609f80a81eb2b18624fcee9534400033L101) and [#2](https://github.com/cabify/aceptadora/pull/14/files#diff-0ccec778a288e27b5a6ada45110d2a1855585629224a3dd4a8b5ff6f9319e283L66))