### PR TITLE
Add ability to restart one container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2025-01-23
+### Added
+- Ability to restart containers
+
 ## [0.5.4] - 2024-09-02
 ### Update
 - Bump `docker/docker` to `v27.2.0`

--- a/acceptance/fixtures/proxy/main.go
+++ b/acceptance/fixtures/proxy/main.go
@@ -7,15 +7,21 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"time"
 )
 
 // This is a dummy reverse proxy to illustrate how our services can access the acceptance tester
 func main() {
 	port := os.Getenv("PROXY_PORT")
 	targetURLRaw := os.Getenv("PROXY_TARGETURL")
+	startedAt := time.Now()
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/status", func(rw http.ResponseWriter, _ *http.Request) {
+		_, err := rw.Write([]byte(fmt.Sprintf("{\"started_at\": %v}", startedAt.UnixMilli())))
+		if err != nil {
+			return
+		}
 		rw.WriteHeader(http.StatusOK)
 	})
 

--- a/aceptadora.go
+++ b/aceptadora.go
@@ -19,6 +19,9 @@ type Config struct {
 	// StopTimeout will be used to stop containers gracefully.
 	// If zero (default), then containers will be forced to stop immediately saving some tear down time.
 	StopTimeout time.Duration `default:"0s"`
+
+	// RestartTimeout will be used to restart containers gracefully.
+	RestartTimeout time.Duration `default:"10s"`
 }
 
 type Aceptadora struct {
@@ -78,6 +81,15 @@ func (a *Aceptadora) Run(ctx context.Context, name string) {
 	runner.Start(ctx)
 	a.services[name] = runner
 	a.order = append(a.order, name)
+}
+
+// Restart will restart the service with the name provided
+func (a *Aceptadora) Restart(ctx context.Context, name string) {
+	svc, ok := a.services[name]
+	if !ok {
+		a.t.Fatalf("There's no service %q to restart", name)
+	}
+	svc.RestartWithTimeout(ctx, a.cfg.RestartTimeout)
 }
 
 // StopAll will stop all the services in the reverse order

--- a/runner.go
+++ b/runner.go
@@ -146,6 +146,21 @@ func (r *Runner) attachAndStreamLogs(ctx context.Context) {
 	r.logsStreamDoneCh = r.streamLogs(r.response)
 }
 
+// RestartWithTimeout will restart the container within the context provided and the timeout given.
+func (r *Runner) RestartWithTimeout(ctx context.Context, timeout time.Duration) {
+	if r.client == nil {
+		// nothing to restart
+		return
+	}
+
+	timeoutSeconds := int(timeout.Seconds())
+	stopOpts := container.StopOptions{Timeout: &timeoutSeconds}
+	if err := r.client.ContainerRestart(ctx, r.container.ID, stopOpts); err != nil {
+		r.t.Errorf("Error restarting container %s: %v", r.container.ID, err)
+	}
+	r.t.Logf("Container %q restarted with ID %q", r.name, r.container.ID)
+}
+
 // Stop will try to stop the container within the context provided.
 func (r *Runner) Stop(ctx context.Context) error {
 	return r.stop(ctx, nil)


### PR DESCRIPTION
It happens that some tests need to restart a container. This PR adds the ability to restart a container by name